### PR TITLE
Support File Skipping

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,32 +9,76 @@ Quickstart
 
 Install from PyPI:
 
-    pip install deltaray
+```shell
+pip install deltaray
+```
 
 Install from GitHub:
 
-    pip install git+https://github.com/delta-incubator/deltaray.git
+```shell
+pip install git+https://github.com/delta-incubator/deltaray.git
+```
 
 Basic use, check notebooks for more detailed example:
 
-    # Standard Libraries
-    import pathlib
-    
-    # External Libraries
-    import deltaray
-    import deltalake as dl
-    import pandas as pd
+```python
+# Standard Libraries
+import pathlib
+
+# External Libraries
+import deltaray
+import deltalake as dl
+import pandas as pd
 
 
-    # Creating a Delta Table
-    cwd = pathlib.Path().resolve()
-    table_uri = f'{cwd}/tmp/delta-table'
-    df = pd.DataFrame({'id': [0, 1, 2, 3, 4, ], })
-    dl.write_deltalake(table_uri, df)
+# Creating a Delta Table
+cwd = pathlib.Path().resolve()
+table_uri = f'{cwd}/tmp/delta-table'
+df = pd.DataFrame({'id': [0, 1, 2, 3, 4, ], })
+dl.write_deltalake(table_uri, df)
 
-    # Reading our Delta Table
-    ds = deltaray.read_delta(table_uri)
-    ds.show()
+# Reading our Delta Table
+ds = deltaray.read_delta(table_uri)
+ds.show()
+```
+
+Improving Read and Query Performance
+------------------------------------
+
+You can make Delta Lake queries faster by using column projection and predicate 
+pushdown. These tools accelerate reads and subsequent queries by reducing the 
+amount of data being sent to the Ray cluster. 
+
+Here's an example of how to query a Delta Table with Ray and take advantage of 
+column pruning and predicate pushdown filters:
+
+```python
+# Standard Libraries
+from pathlib import Path
+
+# External Libraries
+import deltaray
+import deltalake as dl
+import pyarrow.compute as pc
+import pandas as pd
+
+
+# Create a Delta Table
+cwd = Path.cwd()
+table_uri = f'{cwd}/delta-table'
+df = pd.DataFrame({
+    'id': [0, 1, 2, ], 
+    'name': ['Bill', 'Sue', 'Rose'],
+})
+dl.write_deltalake(table_uri, df)
+for person in [{'id': 3, 'name': 'Jake', }, {'id': 4, 'name': 'Sally'}, ]:
+    df = pd.DataFrame([person])
+    dl.write_deltalake(table_uri, df, mode='append')
+
+# Create a Filter
+filters = (pc.field("id") > pc.scalar(3))
+dataset = deltaray.read_delta(table_uri, filters=filters, columns=['name'])
+```
 
 Running Tests
 -------------
@@ -49,15 +93,15 @@ library. It also handles generating reports on test results.
 
 3. Install `tox` for running our test suite and managing our test environments:
 
-    ```bash
-    pip install tox
-   ```
+```bash
+pip install tox
+```
 
 4. Run the test suite from the shell with `tox` while in the cloned repo's directory:
 
-    ```bash
-    tox -s
-   ```
+```bash
+tox -s
+```
 
 note: The `-s` flag prints results to stderr/stdout during pytest-ing.
     
@@ -66,8 +110,12 @@ Building Distribution
 
 Building Wheel:
 
-    python setup.py bdist_wheel sdist
+```shell
+python setup.py bdist_wheel sdist
+```
 
 Installing Wheel:
 
-    pip install /path/to/wheel/..
+```shell
+pip install /path/to/wheel/..
+```

--- a/setup.py
+++ b/setup.py
@@ -4,7 +4,7 @@ import pathlib
 
 
 APP_NAME = "deltaray"
-VERSION = "0.2.0"
+VERSION = "0.3.0"
 LICENSE = "Apache License"
 AUTHOR = "James Hibbard"
 DESCRIPTION = (
@@ -28,8 +28,8 @@ setup(
     long_description_content_type="text/markdown",
     url=URL,
     install_requires=[
-        "deltalake>=0.7.0",
-        "ray[data]>=2.2.0",
+        "deltalake>=0.9.0",
+        "ray[data]>=2.4.0",
         "numpy>=1.24.1",  # typing
     ],
     extras_require={},


### PR DESCRIPTION
You can make Delta Lake queries faster by using column projection and predicate pushdown. These tools accelerate reads and subsequent queries by reducing the amount of data being sent to the Ray cluster.

This PR adds the `filters` argument to the `read_delta` method within `deltaray`. The `filters` argument accepts a PyArrow dataset expression, documentation [here](https://arrow.apache.org/docs/python/generated/pyarrow.dataset.Expression.html#pyarrow.dataset.Expression). This can be used to query Delta tables with Ray while taking advantage of both column pruning and now predicate pushdown filters. Example below:

```python
# Standard Libraries
from pathlib import Path

# External Libraries
import deltaray
import deltalake as dl
import pyarrow.compute as pc
import pandas as pd


# Create a Delta Table
cwd = Path.cwd()
table_uri = f'{cwd}/delta-table'
df = pd.DataFrame({
    'id': [0, 1, 2, ], 
    'name': ['Bill', 'Sue', 'Rose'],
})
dl.write_deltalake(table_uri, df)
for person in [{'id': 3, 'name': 'Jake', }, {'id': 4, 'name': 'Sally'}, ]:
    df = pd.DataFrame([person])
    dl.write_deltalake(table_uri, df, mode='append')

# Create a Filter
filters = (pc.field("id") > pc.scalar(3))
dataset = deltaray.read_delta(table_uri, filters=filters, columns=['name'])
```

If accepted, this PR will close [issue 1](https://github.com/delta-incubator/deltaray/issues/1) and support file skipping via filters.